### PR TITLE
Guard tmux reattach in linux

### DIFF
--- a/files/.tmux.conf
+++ b/files/.tmux.conf
@@ -24,7 +24,7 @@ set -sg escape-time 1
 # session options
 set -g prefix C-a
 set -g base-index 1
-set -g default-command "reattach-to-user-namespace -l zsh"
+if-shell 'if [[ "$(uname)" == "Darwin" ]]; then true; else false; fi' 'set -g default-command "reattach-to-user-namespace -l zsh"'
 set -g default-terminal "screen-256color"
 
 # window options


### PR DESCRIPTION
#### Problem

In linux this breaks tmux

#### Solution

make it an osx only thing


 - I'm not in love with not having a osx()/linux() function like you have for utils during setup, think it's worth just having?
 - the .gitconfig being shared makes everything a huge pain in the ass
 - i have some fasd things (it's not apt-get able), i suspect you'll never use them