### PR TITLE
ruby_install requires sudo, add artful dockerfile

### DIFF
--- a/Dockerfile.artful
+++ b/Dockerfile.artful
@@ -1,0 +1,12 @@
+FROM ubuntu:17.10
+RUN apt-get -y update && apt-get -y install curl make sudo
+RUN useradd -ms /bin/bash testuser && adduser testuser sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER testuser
+RUN mkdir /home/testuser/dotfiles
+
+ADD . /home/testuser/dotfiles
+WORKDIR /home/testuser/dotfiles
+
+CMD ["bin/setup", "-a"]

--- a/lib/deltas/ruby-install.sh
+++ b/lib/deltas/ruby-install.sh
@@ -16,7 +16,7 @@ apply() {
   extract_archive "/tmp/v${version}.tar.gz" || return $?
 
   pushd /tmp/ruby-install-${version} >/dev/null
-  make install
+  sudo make install
   popd >/dev/null
 
   rm -rf /tmp/v${version}.tar.gz /tmp/ruby-install-${version}


### PR DESCRIPTION
May be lumping too many things together

 - ruby_install requires sudo, so just add it FIX https://github.com/karlhungus/dotfiles/issues/9
 - add an artful (distro i'm on) build

Note:
 ruby 2.3.1 segfults for me, imo i'd rather just have the latest ruby and update these two dependancies to be 2.4.1 (or whatever is current), and add old rubys a-la-cart, that seem reasonable to you -- if so i'll update this https://github.com/karlhungus/dotfiles/blob/8d410f3f764c5dc43be62e716915e105598f76a5/lib/phases.sh#L62?

@pseudomuto 